### PR TITLE
Closes #210. Making sure maxLatency is not set to -1 by default. This ti...

### DIFF
--- a/commons/src/main/java/org/calrissian/accumulorecipes/commons/domain/StoreConfig.java
+++ b/commons/src/main/java/org/calrissian/accumulorecipes/commons/domain/StoreConfig.java
@@ -36,7 +36,7 @@ public class StoreConfig {
      * @param maxQueryThreads the number of concurrent threads to spawn for querying
      */
     public StoreConfig(int maxQueryThreads) {
-        this(maxQueryThreads, 10000, 10000, 1);
+        this(maxQueryThreads, 1024 * 1024 * 1000, 120 * 1000 * 60, 1);
     }
 
     /**


### PR DESCRIPTION
...cket will be followed on by an API change to get rid of StoreConfig and use BatchWriterConfig and BatchScanConfig
