### PR TITLE
Fixes #296 Better planning before queries are run to try to eliminate shards that will never match the query.

### DIFF
--- a/commons/src/main/java/org/calrissian/accumulorecipes/commons/hadoop/BaseQfdInputFormat.java
+++ b/commons/src/main/java/org/calrissian/accumulorecipes/commons/hadoop/BaseQfdInputFormat.java
@@ -46,7 +46,7 @@ import org.calrissian.accumulorecipes.commons.iterators.BooleanLogicIterator;
 import org.calrissian.accumulorecipes.commons.iterators.OptimizedQueryIterator;
 import org.calrissian.accumulorecipes.commons.iterators.SelectFieldsExtractor;
 import org.calrissian.accumulorecipes.commons.iterators.support.NodeToJexl;
-import org.calrissian.accumulorecipes.commons.support.criteria.QueryOptimizer;
+import org.calrissian.accumulorecipes.commons.support.criteria.LogicalPlan;
 import org.calrissian.accumulorecipes.commons.support.criteria.visitors.GlobalIndexVisitor;
 import org.calrissian.mango.criteria.domain.Node;
 import org.calrissian.mango.domain.TupleStore;
@@ -64,7 +64,7 @@ public abstract class BaseQfdInputFormat<T extends TupleStore, W extends Settabl
         TypeRegistry<String> typeRegistry, Class<? extends OptimizedQueryIterator> optimizedQueryIteratorClass)
           throws AccumuloSecurityException, AccumuloException, TableNotFoundException {
 
-        QueryOptimizer optimizer = new QueryOptimizer(query, globalInexVisitor, typeRegistry);
+        LogicalPlan optimizer = new LogicalPlan(query, globalInexVisitor, typeRegistry);
         String jexl = nodeToJexl.transform(types, optimizer.getOptimizedQuery());
         String originalJexl = nodeToJexl.transform(types, query);
 

--- a/commons/src/main/java/org/calrissian/accumulorecipes/commons/hadoop/BaseQfdInputFormat.java
+++ b/commons/src/main/java/org/calrissian/accumulorecipes/commons/hadoop/BaseQfdInputFormat.java
@@ -64,18 +64,18 @@ public abstract class BaseQfdInputFormat<T extends TupleStore, W extends Settabl
         TypeRegistry<String> typeRegistry, Class<? extends OptimizedQueryIterator> optimizedQueryIteratorClass)
           throws AccumuloSecurityException, AccumuloException, TableNotFoundException {
 
-        LogicalPlan optimizer = new LogicalPlan(query, globalInexVisitor, typeRegistry);
-        String jexl = nodeToJexl.transform(types, optimizer.getOptimizedQuery());
+        LogicalPlan logicalPlan = new LogicalPlan(query, globalInexVisitor, typeRegistry);
+        String jexl = nodeToJexl.transform(types, logicalPlan.getOptimizedQuery());
         String originalJexl = nodeToJexl.transform(types, query);
 
         log.debug("Original Jexl: "+ originalJexl);
         log.debug("Optimized Jexl: "+ jexl);
 
         Collection<Range> ranges = new ArrayList<Range>();
-        if(jexl.equals("()") || jexl.equals("")) {
+        if(jexl.equals("()") || jexl.equals("") || logicalPlan.getShards().size() == 0) {
             ranges.add(new Range(END_BYTE));
         } else {
-            for (String shard : optimizer.getShards())
+            for (String shard : logicalPlan.getShards())
                 ranges.add(new Range(shard));
         }
 

--- a/commons/src/main/java/org/calrissian/accumulorecipes/commons/support/criteria/BaseCardinalityKey.java
+++ b/commons/src/main/java/org/calrissian/accumulorecipes/commons/support/criteria/BaseCardinalityKey.java
@@ -15,7 +15,7 @@
  */
 package org.calrissian.accumulorecipes.commons.support.criteria;
 
-public class BaseCardinalityKey implements CardinalityKey {
+public class BaseCardinalityKey implements TupleIndexKey {
 
     protected String key;
     protected String normalizedValue;
@@ -23,13 +23,6 @@ public class BaseCardinalityKey implements CardinalityKey {
     protected String shard;
 
     protected BaseCardinalityKey() {
-    }
-
-    public BaseCardinalityKey(String key, String value, String alias, String shard) {
-        this.key = key;
-        this.normalizedValue = value;
-        this.alias = alias;
-        this.shard = shard;
     }
 
     public BaseCardinalityKey(String key, String value, String alias) {

--- a/commons/src/main/java/org/calrissian/accumulorecipes/commons/support/criteria/LogicalPlan.java
+++ b/commons/src/main/java/org/calrissian/accumulorecipes/commons/support/criteria/LogicalPlan.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.calrissian.mango.criteria.support.NodeUtils.isEmpty;
 import java.util.Set;
 
+import org.calrissian.accumulorecipes.commons.support.criteria.visitors.CalculateShardsVisitor;
 import org.calrissian.accumulorecipes.commons.support.criteria.visitors.CardinalityReorderVisitor;
 import org.calrissian.accumulorecipes.commons.support.criteria.visitors.ExtractInNotInVisitor;
 import org.calrissian.accumulorecipes.commons.support.criteria.visitors.ExtractRangesVisitor;
@@ -38,14 +39,15 @@ import org.calrissian.mango.types.TypeRegistry;
 /**
  * Visit criteria to validate and config to perform the criteria against the event service.
  */
-public class QueryOptimizer implements NodeVisitor {
+public class LogicalPlan implements NodeVisitor {
 
     protected Node node;
+    protected Set<String> shards;
     protected Set<String> keysInQuery;
     protected GlobalIndexVisitor indexVisitor;
     protected TypeRegistry<String> typeRegistry;
 
-    public QueryOptimizer(Node query, GlobalIndexVisitor indexVisitor, TypeRegistry<String> typeRegistry) {
+    public LogicalPlan(Node query, GlobalIndexVisitor indexVisitor, TypeRegistry<String> typeRegistry) {
         checkNotNull(query);
 
         this.node = query.clone(null);  // cloned so that original is not modified during optimization
@@ -55,7 +57,7 @@ public class QueryOptimizer implements NodeVisitor {
         init();
     }
 
-    public QueryOptimizer(Node query, TypeRegistry<String> typeRegistry) {
+    public LogicalPlan(Node query, TypeRegistry<String> typeRegistry) {
         this(query, null, typeRegistry);
     }
 
@@ -72,6 +74,10 @@ public class QueryOptimizer implements NodeVisitor {
                 node.accept(indexVisitor);
                 indexVisitor.exec();
                 node.accept(new CardinalityReorderVisitor(indexVisitor.getCardinalities(), typeRegistry));
+
+                CalculateShardsVisitor calculateShardsVisitor = new CalculateShardsVisitor(indexVisitor.getShards(), typeRegistry);
+                node.accept(calculateShardsVisitor);
+                shards = calculateShardsVisitor.getShards();
             }
 
             Node previous = node.clone(null);
@@ -128,8 +134,9 @@ public class QueryOptimizer implements NodeVisitor {
     }
 
     public Set<String> getShards() {
+
         if (indexVisitor != null)
-            return indexVisitor.getShards();
+            return shards;
         else
             throw new RuntimeException("A global index visitor was not configured on this optimizer.");
     }

--- a/commons/src/main/java/org/calrissian/accumulorecipes/commons/support/criteria/LogicalPlan.java
+++ b/commons/src/main/java/org/calrissian/accumulorecipes/commons/support/criteria/LogicalPlan.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.calrissian.mango.criteria.support.NodeUtils.isEmpty;
 import java.util.Set;
 
+import com.google.common.collect.Sets;
 import org.calrissian.accumulorecipes.commons.support.criteria.visitors.CalculateShardsVisitor;
 import org.calrissian.accumulorecipes.commons.support.criteria.visitors.CardinalityReorderVisitor;
 import org.calrissian.accumulorecipes.commons.support.criteria.visitors.ExtractInNotInVisitor;
@@ -42,7 +43,7 @@ import org.calrissian.mango.types.TypeRegistry;
 public class LogicalPlan implements NodeVisitor {
 
     protected Node node;
-    protected Set<String> shards;
+    protected Set<String> shards = Sets.newHashSet();
     protected Set<String> keysInQuery;
     protected GlobalIndexVisitor indexVisitor;
     protected TypeRegistry<String> typeRegistry;

--- a/commons/src/main/java/org/calrissian/accumulorecipes/commons/support/criteria/TupleIndexKey.java
+++ b/commons/src/main/java/org/calrissian/accumulorecipes/commons/support/criteria/TupleIndexKey.java
@@ -15,7 +15,7 @@
  */
 package org.calrissian.accumulorecipes.commons.support.criteria;
 
-public interface CardinalityKey {
+public interface TupleIndexKey {
 
 
     String getKey();

--- a/commons/src/main/java/org/calrissian/accumulorecipes/commons/support/criteria/visitors/CalculateShardsVisitor.java
+++ b/commons/src/main/java/org/calrissian/accumulorecipes/commons/support/criteria/visitors/CalculateShardsVisitor.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2015 The Calrissian Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.calrissian.accumulorecipes.commons.support.criteria.visitors;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.Sets;
+import org.calrissian.accumulorecipes.commons.support.criteria.BaseCardinalityKey;
+import org.calrissian.accumulorecipes.commons.support.criteria.CardinalityKey;
+import org.calrissian.mango.criteria.domain.AbstractKeyValueLeaf;
+import org.calrissian.mango.criteria.domain.AndNode;
+import org.calrissian.mango.criteria.domain.HasLeaf;
+import org.calrissian.mango.criteria.domain.HasNotLeaf;
+import org.calrissian.mango.criteria.domain.Leaf;
+import org.calrissian.mango.criteria.domain.NegationLeaf;
+import org.calrissian.mango.criteria.domain.Node;
+import org.calrissian.mango.criteria.domain.OrNode;
+import org.calrissian.mango.criteria.domain.ParentNode;
+import org.calrissian.mango.criteria.support.NodeUtils;
+import org.calrissian.mango.criteria.visitor.NodeVisitor;
+import org.calrissian.mango.types.TypeRegistry;
+
+public class CalculateShardsVisitor implements NodeVisitor {
+
+    private final Map<CardinalityKey,Set<String>> keysToShards;
+    private Map<String, Set<CardinalityKey>> keyToCarinalityKey = new HashMap<String, Set<CardinalityKey>>();
+    private TypeRegistry<String> registry;
+
+    private Set<String> finalShards;
+
+    public CalculateShardsVisitor(Map<CardinalityKey,Set<String>> shards, TypeRegistry<String> registry) {
+        this.keysToShards = shards;
+        this.registry = registry;
+
+        // TODO: This is shared w/ the ReorderVisitor- pull it out into a central location
+        for (CardinalityKey key : shards.keySet()) {
+            Set<CardinalityKey> cardinalityKey = keyToCarinalityKey.get(key.getKey());
+            if (cardinalityKey == null) {
+                cardinalityKey = new HashSet<CardinalityKey>();
+                keyToCarinalityKey.put(key.getKey(), cardinalityKey);
+            }
+            cardinalityKey.add(key);
+        }
+    }
+
+    @Override
+    public void begin(ParentNode parentNode) {
+        if(finalShards == null)
+            finalShards = getShards(parentNode);
+    }
+
+    @Override
+    public void end(ParentNode parentNode) {
+
+    }
+
+    @Override
+    public void visit(Leaf leaf) {
+
+    }
+
+    public Set<String> getShards() {
+        return finalShards;
+    }
+
+    private Set<String> getShards(ParentNode node) {
+
+        Set<Set<String>> finalShards = new HashSet<Set<String>>();
+        for (Node child : node.children()) {
+            if (child instanceof AndNode || child instanceof OrNode)
+                finalShards.add(getShards((ParentNode) child));
+            else if (child instanceof Leaf)  {
+                Set<String> childShards = getShards((Leaf) child);
+
+
+                //if a negated leaf didn't return any shards, we should just ignore it
+                finalShards.add(childShards);
+            }
+        }
+
+        Set<String> combinedSet = null;
+        // if the parent is an AndNode, we need to intersect keysToShards
+        if(node instanceof AndNode) {
+            for(Set<String> curShards : finalShards) {
+                if(combinedSet == null)
+                    combinedSet = curShards;
+                else {
+                    Set<String> intersected = Sets.intersection(combinedSet, curShards);
+                    combinedSet = new HashSet<String>(intersected);
+                }
+            }
+
+        // otherwise the paren is an OrNode, and we need to union
+        } else {
+            for(Set<String> curShards : finalShards) {
+                if(combinedSet == null)
+                    combinedSet = Sets.newHashSet();
+                combinedSet.addAll(curShards);
+            }
+        }
+
+        return combinedSet;
+    }
+
+    private Set<String> getShards(Leaf leaf) {
+        AbstractKeyValueLeaf kvLeaf = (AbstractKeyValueLeaf) leaf;
+
+        // hasKey and hasNotKey need special treatment since we don't know the aliases
+        if (leaf instanceof HasLeaf || leaf instanceof HasNotLeaf || NodeUtils.isRangeLeaf(leaf)) {
+            Set<CardinalityKey> cardinalityKeys = keyToCarinalityKey.get(kvLeaf.getKey());
+            Set<String> unionedShards = new HashSet<String>();
+            if (cardinalityKeys == null) {
+                if (leaf instanceof NegationLeaf)
+                    return unionedShards;
+            } else {
+                for (CardinalityKey key : cardinalityKeys) {
+                    unionedShards.addAll(this.keysToShards.get(key));
+                }
+            }
+
+            return unionedShards;
+        } else {
+            String alias = registry.getAlias(kvLeaf.getValue());
+            String normalizedVal = null;
+            normalizedVal = registry.encode(kvLeaf.getValue());
+
+            CardinalityKey cardinalityKey = new BaseCardinalityKey(kvLeaf.getKey(), normalizedVal, alias);
+            Set<String> leafShards = keysToShards.get(cardinalityKey);
+
+            if (leafShards == null)
+                return Sets.newHashSet();
+
+            return leafShards;
+        }
+    }
+}

--- a/commons/src/main/java/org/calrissian/accumulorecipes/commons/support/criteria/visitors/CardinalityReorderVisitor.java
+++ b/commons/src/main/java/org/calrissian/accumulorecipes/commons/support/criteria/visitors/CardinalityReorderVisitor.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.calrissian.accumulorecipes.commons.support.criteria.BaseCardinalityKey;
-import org.calrissian.accumulorecipes.commons.support.criteria.CardinalityKey;
+import org.calrissian.accumulorecipes.commons.support.criteria.TupleIndexKey;
 import org.calrissian.mango.criteria.domain.AbstractKeyValueLeaf;
 import org.calrissian.mango.criteria.domain.AndNode;
 import org.calrissian.mango.criteria.domain.HasLeaf;
@@ -42,16 +42,16 @@ import static java.util.Collections.sort;
 public class CardinalityReorderVisitor implements NodeVisitor {
 
     private static TypeRegistry<String> registry;
-    private Map<CardinalityKey, Long> cardinalities;
-    private Map<String, Set<CardinalityKey>> keyToCarinalityKey = new HashMap<String, Set<CardinalityKey>>();
+    private Map<TupleIndexKey, Long> cardinalities;
+    private Map<String, Set<TupleIndexKey>> keyToCarinalityKey = new HashMap<String, Set<TupleIndexKey>>();
 
-    public CardinalityReorderVisitor(Map<CardinalityKey, Long> cardinalities, TypeRegistry<String> typeRegistry) {
+    public CardinalityReorderVisitor(Map<TupleIndexKey, Long> cardinalities, TypeRegistry<String> typeRegistry) {
         this.cardinalities = cardinalities;
         this.registry = typeRegistry;
-        for (CardinalityKey key : cardinalities.keySet()) {
-            Set<CardinalityKey> cardinalityKey = keyToCarinalityKey.get(key.getKey());
+        for (TupleIndexKey key : cardinalities.keySet()) {
+            Set<TupleIndexKey> cardinalityKey = keyToCarinalityKey.get(key.getKey());
             if (cardinalityKey == null) {
-                cardinalityKey = new HashSet<CardinalityKey>();
+                cardinalityKey = new HashSet<TupleIndexKey>();
                 keyToCarinalityKey.put(key.getKey(), cardinalityKey);
             }
             cardinalityKey.add(key);
@@ -117,14 +117,14 @@ public class CardinalityReorderVisitor implements NodeVisitor {
 
         // hasKey and hasNotKey need special treatment since we don't know the aliases
         if (leaf instanceof HasLeaf || leaf instanceof HasNotLeaf || NodeUtils.isRangeLeaf(leaf)) {
-            Set<CardinalityKey> cardinalityKeys = keyToCarinalityKey.get(kvLeaf.getKey());
+            Set<TupleIndexKey> cardinalityKeys = keyToCarinalityKey.get(kvLeaf.getKey());
 
             Long cardinality = 0l;
             if (cardinalityKeys == null) {
                 if (leaf instanceof NegationLeaf)
                     return 1;
             } else {
-                for (CardinalityKey key : cardinalityKeys) {
+                for (TupleIndexKey key : cardinalityKeys) {
                     cardinality += this.cardinalities.get(key);
                 }
             }
@@ -135,7 +135,7 @@ public class CardinalityReorderVisitor implements NodeVisitor {
             String normalizedVal = null;
             normalizedVal = registry.encode(kvLeaf.getValue());
 
-            CardinalityKey cardinalityKey = new BaseCardinalityKey(kvLeaf.getKey(), normalizedVal, alias);
+            TupleIndexKey cardinalityKey = new BaseCardinalityKey(kvLeaf.getKey(), normalizedVal, alias);
             Long cardinality = cardinalities.get(cardinalityKey);
 
             if (cardinality == null) {

--- a/commons/src/main/java/org/calrissian/accumulorecipes/commons/support/criteria/visitors/GlobalIndexVisitor.java
+++ b/commons/src/main/java/org/calrissian/accumulorecipes/commons/support/criteria/visitors/GlobalIndexVisitor.java
@@ -18,14 +18,14 @@ package org.calrissian.accumulorecipes.commons.support.criteria.visitors;
 import java.util.Map;
 import java.util.Set;
 
-import org.calrissian.accumulorecipes.commons.support.criteria.CardinalityKey;
+import org.calrissian.accumulorecipes.commons.support.criteria.TupleIndexKey;
 import org.calrissian.mango.criteria.visitor.NodeVisitor;
 
 public interface GlobalIndexVisitor extends NodeVisitor {
 
-    Map<CardinalityKey, Long> getCardinalities();
+    Map<TupleIndexKey, Long> getCardinalities();
 
-    Map<CardinalityKey, Set<String>> getShards();
+    Map<TupleIndexKey, Set<String>> getShards();
 
     void exec();
 }

--- a/commons/src/main/java/org/calrissian/accumulorecipes/commons/support/criteria/visitors/GlobalIndexVisitor.java
+++ b/commons/src/main/java/org/calrissian/accumulorecipes/commons/support/criteria/visitors/GlobalIndexVisitor.java
@@ -15,17 +15,17 @@
  */
 package org.calrissian.accumulorecipes.commons.support.criteria.visitors;
 
-import org.calrissian.accumulorecipes.commons.support.criteria.CardinalityKey;
-import org.calrissian.mango.criteria.visitor.NodeVisitor;
-
 import java.util.Map;
 import java.util.Set;
+
+import org.calrissian.accumulorecipes.commons.support.criteria.CardinalityKey;
+import org.calrissian.mango.criteria.visitor.NodeVisitor;
 
 public interface GlobalIndexVisitor extends NodeVisitor {
 
     Map<CardinalityKey, Long> getCardinalities();
 
-    Set<String> getShards();
+    Map<CardinalityKey, Set<String>> getShards();
 
     void exec();
 }

--- a/commons/src/main/java/org/calrissian/accumulorecipes/commons/support/qfd/QfdHelper.java
+++ b/commons/src/main/java/org/calrissian/accumulorecipes/commons/support/qfd/QfdHelper.java
@@ -65,7 +65,7 @@ import org.calrissian.accumulorecipes.commons.iterators.GlobalIndexCombiner;
 import org.calrissian.accumulorecipes.commons.iterators.GlobalIndexExpirationFilter;
 import org.calrissian.accumulorecipes.commons.iterators.OptimizedQueryIterator;
 import org.calrissian.accumulorecipes.commons.iterators.support.NodeToJexl;
-import org.calrissian.accumulorecipes.commons.support.criteria.QueryOptimizer;
+import org.calrissian.accumulorecipes.commons.support.criteria.LogicalPlan;
 import org.calrissian.accumulorecipes.commons.support.criteria.visitors.GlobalIndexVisitor;
 import org.calrissian.accumulorecipes.commons.support.metadata.MetadataSerDe;
 import org.calrissian.accumulorecipes.commons.support.metadata.MetadataSerdeFactory;
@@ -244,7 +244,7 @@ public abstract class QfdHelper<T extends Entity> {
         checkNotNull(query);
         checkNotNull(auths);
 
-        QueryOptimizer optimizer = new QueryOptimizer(query, globalIndexVisitor, typeRegistry);
+        LogicalPlan optimizer = new LogicalPlan(query, globalIndexVisitor, typeRegistry);
 
         if (NodeUtils.isEmpty(optimizer.getOptimizedQuery()))
             return wrap(EMPTY_LIST);

--- a/commons/src/test/java/org/calrissian/accumulorecipes/commons/support/criteria/visitors/CalculateShardsVisitorTest.java
+++ b/commons/src/test/java/org/calrissian/accumulorecipes/commons/support/criteria/visitors/CalculateShardsVisitorTest.java
@@ -30,21 +30,32 @@ import org.junit.Test;
 
 public class CalculateShardsVisitorTest {
 
+    private CalculateShardsVisitor runShardsVisitor(Node node) {
 
-    @Test
-    public void shardRollUpInAndNode() {
         Map<TupleIndexKey,Set<String>> shards = new HashMap<TupleIndexKey, Set<String>>();
         shards.put(new BaseCardinalityKey("key1", "val1", "string"), Sets.newHashSet("1", "2"));
         shards.put(new BaseCardinalityKey("key2", "val2", "string"), Sets.newHashSet("2", "3"));
         shards.put(new BaseCardinalityKey("key3", "val3", "string"), Sets.newHashSet("2", "5"));
 
-        Node node = new QueryBuilder().and().eq("key3", "val3").and().eq("key2", "val2").eq("key1", "val1")
-            .end().end().build();
-
         CalculateShardsVisitor visitor = new CalculateShardsVisitor(shards, LexiTypeEncoders.LEXI_TYPES);
         node.accept(visitor);
 
         System.out.println(visitor.getShards());
+
+        return visitor;
+    }
+
+
+    @Test
+    public void shardRollUpInAndNode() {
+
+        /**
+         * The result of an AND nested within an AND with an EQ as a sibling
+         */
+        Node node = new QueryBuilder().and().eq("key3", "val3").and().eq("key2", "val2").eq("key1", "val1")
+            .end().end().build();
+
+        CalculateShardsVisitor visitor = runShardsVisitor(node);
 
         assertEquals(1, visitor.getShards().size());
         assertEquals("2", visitor.getShards().iterator().next());
@@ -53,38 +64,120 @@ public class CalculateShardsVisitorTest {
 
     @Test
     public void shardRollUpInOrNode() {
-        Map<TupleIndexKey,Set<String>> shards = new HashMap<TupleIndexKey, Set<String>>();
-        shards.put(new BaseCardinalityKey("key1", "val1", "string"), Sets.newHashSet("1", "2"));
-        shards.put(new BaseCardinalityKey("key2", "val2", "string"), Sets.newHashSet("2", "3"));
-        shards.put(new BaseCardinalityKey("key3", "val3", "string"), Sets.newHashSet("2", "5"));
 
+        /**
+         * The result of nesting an OR within an OR with an EQ as a sibling
+         */
         Node node = new QueryBuilder().or().eq("key3", "val3").or().eq("key2", "val2").eq("key1", "val1")
             .end().end().build();
 
-        CalculateShardsVisitor visitor = new CalculateShardsVisitor(shards, LexiTypeEncoders.LEXI_TYPES);
-        node.accept(visitor);
-
-        System.out.println(visitor.getShards());
+        CalculateShardsVisitor visitor = runShardsVisitor(node);
 
         assertEquals(4, visitor.getShards().size());
     }
 
     @Test
     public void shardRollUpAlternatingAndOrNodes() {
-        Map<TupleIndexKey,Set<String>> shards = new HashMap<TupleIndexKey, Set<String>>();
-        shards.put(new BaseCardinalityKey("key1", "val1", "string"), Sets.newHashSet("1", "2"));
-        shards.put(new BaseCardinalityKey("key2", "val2", "string"), Sets.newHashSet("2", "3"));
-        shards.put(new BaseCardinalityKey("key3", "val3", "string"), Sets.newHashSet("2", "5"));
 
+        /**
+         * The result of nesting an AND within an OR with an EQ as a sibling
+         */
         Node node = new QueryBuilder().or().eq("key3", "val3").and().eq("key2", "val2").eq("key1", "val1")
             .end().end().build();
 
-        CalculateShardsVisitor visitor = new CalculateShardsVisitor(shards, LexiTypeEncoders.LEXI_TYPES);
-        node.accept(visitor);
-
-        System.out.println(visitor.getShards());
+        CalculateShardsVisitor visitor = runShardsVisitor(node);
 
         assertEquals(2, visitor.getShards().size());
     }
+
+
+    @Test
+    public void shardRollUpAlternatingOrAndNodes() {
+
+        /**
+         * The result of nesting an OR within an AND with an EQ as a sibling
+         */
+        Node node = new QueryBuilder().and().eq("key3", "val3").or().eq("key2", "val2").eq("key1", "val1")
+            .end().end().build();
+
+        CalculateShardsVisitor visitor = runShardsVisitor(node);
+
+        assertEquals(1, visitor.getShards().size());
+    }
+
+    @Test
+    public void shardRollUpAndNodesSomeDontExist() {
+
+        /**
+         * When we have a node that doesn't exist in an and, we shouldn't scan any shards
+         */
+        Node node = new QueryBuilder().and().eq("key4", "val2").eq("key2", "val2").end().build();
+
+        CalculateShardsVisitor visitor = runShardsVisitor(node);
+
+        assertEquals(0, visitor.getShards().size());
+    }
+
+
+    @Test
+    public void shardRollUpAndOrNodesSomeDontExist() {
+
+        /**
+         * When we have a node that doesn't exist in an and, the whole and should should fail but the or
+         * should have shards
+         */
+        Node node = new QueryBuilder().or().eq("key1", "val1").and().eq("key4", "val2").eq("key2", "val2")
+            .end().end().build();
+
+        CalculateShardsVisitor visitor = runShardsVisitor(node);
+
+        assertEquals(2, visitor.getShards().size());
+    }
+
+    @Test
+    public void shardRollUpOrNodesNegationNodesInAnd() {
+
+        /**
+         * When we have a negation node and we OR that with another node.
+         */
+        Node node = new QueryBuilder().or().eq("key1", "val1").and().notEq("key2", "val2")
+            .end().end().build();
+
+        CalculateShardsVisitor visitor = runShardsVisitor(node);
+
+        assertEquals(3, visitor.getShards().size());
+    }
+
+
+    @Test
+    public void shardRollUpAndNodesNegationNodesInOr() {
+
+        /**
+         * This pretty much becomes an and. The only shard in common is 2
+         */
+        Node node = new QueryBuilder().and().eq("key1", "val1").or().notEq("key2", "val2")
+            .end().end().build();
+
+        CalculateShardsVisitor visitor = runShardsVisitor(node);
+
+        assertEquals(1, visitor.getShards().size());
+    }
+
+
+    @Test
+    public void test() {
+
+        /**
+         * The result of nesting an OR within an AND with an EQ as a sibling
+         */
+        Node node = new QueryBuilder().and().greaterThan("key1", "val1").lessThan("key2", "val2").notEq("key1", "hellp")
+            .end().build();
+
+        CalculateShardsVisitor visitor = runShardsVisitor(node);
+
+        assertEquals(1, visitor.getShards().size());
+    }
+
+
 
 }

--- a/commons/src/test/java/org/calrissian/accumulorecipes/commons/support/criteria/visitors/CalculateShardsVisitorTest.java
+++ b/commons/src/test/java/org/calrissian/accumulorecipes/commons/support/criteria/visitors/CalculateShardsVisitorTest.java
@@ -1,0 +1,75 @@
+package org.calrissian.accumulorecipes.commons.support.criteria.visitors;
+
+import static org.junit.Assert.assertEquals;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.Sets;
+import org.calrissian.accumulorecipes.commons.support.criteria.BaseCardinalityKey;
+import org.calrissian.accumulorecipes.commons.support.criteria.CardinalityKey;
+import org.calrissian.mango.criteria.builder.QueryBuilder;
+import org.calrissian.mango.criteria.domain.Node;
+import org.calrissian.mango.types.LexiTypeEncoders;
+import org.junit.Test;
+
+public class CalculateShardsVisitorTest {
+
+
+    @Test
+    public void shardRollUpInAndNode() {
+        Map<CardinalityKey,Set<String>> shards = new HashMap<CardinalityKey, Set<String>>();
+        shards.put(new BaseCardinalityKey("key1", "val1", "string"), Sets.newHashSet("1", "2"));
+        shards.put(new BaseCardinalityKey("key2", "val2", "string"), Sets.newHashSet("2", "3"));
+        shards.put(new BaseCardinalityKey("key3", "val3", "string"), Sets.newHashSet("2", "5"));
+
+        Node node = new QueryBuilder().and().eq("key3", "val3").and().eq("key2", "val2").eq("key1", "val1")
+            .end().end().build();
+
+        CalculateShardsVisitor visitor = new CalculateShardsVisitor(shards, LexiTypeEncoders.LEXI_TYPES);
+        node.accept(visitor);
+
+        System.out.println(visitor.getShards());
+
+        assertEquals(1, visitor.getShards().size());
+        assertEquals("2", visitor.getShards().iterator().next());
+    }
+
+
+    @Test
+    public void shardRollUpInOrNode() {
+        Map<CardinalityKey,Set<String>> shards = new HashMap<CardinalityKey, Set<String>>();
+        shards.put(new BaseCardinalityKey("key1", "val1", "string"), Sets.newHashSet("1", "2"));
+        shards.put(new BaseCardinalityKey("key2", "val2", "string"), Sets.newHashSet("2", "3"));
+        shards.put(new BaseCardinalityKey("key3", "val3", "string"), Sets.newHashSet("2", "5"));
+
+        Node node = new QueryBuilder().or().eq("key3", "val3").or().eq("key2", "val2").eq("key1", "val1")
+            .end().end().build();
+
+        CalculateShardsVisitor visitor = new CalculateShardsVisitor(shards, LexiTypeEncoders.LEXI_TYPES);
+        node.accept(visitor);
+
+        System.out.println(visitor.getShards());
+
+        assertEquals(4, visitor.getShards().size());
+    }
+
+    @Test
+    public void shardRollUpAlternatingAndOrNodes() {
+        Map<CardinalityKey,Set<String>> shards = new HashMap<CardinalityKey, Set<String>>();
+        shards.put(new BaseCardinalityKey("key1", "val1", "string"), Sets.newHashSet("1", "2"));
+        shards.put(new BaseCardinalityKey("key2", "val2", "string"), Sets.newHashSet("2", "3"));
+        shards.put(new BaseCardinalityKey("key3", "val3", "string"), Sets.newHashSet("2", "5"));
+
+        Node node = new QueryBuilder().or().eq("key3", "val3").and().eq("key2", "val2").eq("key1", "val1")
+            .end().end().build();
+
+        CalculateShardsVisitor visitor = new CalculateShardsVisitor(shards, LexiTypeEncoders.LEXI_TYPES);
+        node.accept(visitor);
+
+        System.out.println(visitor.getShards());
+
+        assertEquals(2, visitor.getShards().size());
+    }
+
+}

--- a/commons/src/test/java/org/calrissian/accumulorecipes/commons/support/criteria/visitors/CalculateShardsVisitorTest.java
+++ b/commons/src/test/java/org/calrissian/accumulorecipes/commons/support/criteria/visitors/CalculateShardsVisitorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2015 The Calrissian Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.calrissian.accumulorecipes.commons.support.criteria.visitors;
 
 import static org.junit.Assert.assertEquals;
@@ -7,7 +22,7 @@ import java.util.Set;
 
 import com.google.common.collect.Sets;
 import org.calrissian.accumulorecipes.commons.support.criteria.BaseCardinalityKey;
-import org.calrissian.accumulorecipes.commons.support.criteria.CardinalityKey;
+import org.calrissian.accumulorecipes.commons.support.criteria.TupleIndexKey;
 import org.calrissian.mango.criteria.builder.QueryBuilder;
 import org.calrissian.mango.criteria.domain.Node;
 import org.calrissian.mango.types.LexiTypeEncoders;
@@ -18,7 +33,7 @@ public class CalculateShardsVisitorTest {
 
     @Test
     public void shardRollUpInAndNode() {
-        Map<CardinalityKey,Set<String>> shards = new HashMap<CardinalityKey, Set<String>>();
+        Map<TupleIndexKey,Set<String>> shards = new HashMap<TupleIndexKey, Set<String>>();
         shards.put(new BaseCardinalityKey("key1", "val1", "string"), Sets.newHashSet("1", "2"));
         shards.put(new BaseCardinalityKey("key2", "val2", "string"), Sets.newHashSet("2", "3"));
         shards.put(new BaseCardinalityKey("key3", "val3", "string"), Sets.newHashSet("2", "5"));
@@ -38,7 +53,7 @@ public class CalculateShardsVisitorTest {
 
     @Test
     public void shardRollUpInOrNode() {
-        Map<CardinalityKey,Set<String>> shards = new HashMap<CardinalityKey, Set<String>>();
+        Map<TupleIndexKey,Set<String>> shards = new HashMap<TupleIndexKey, Set<String>>();
         shards.put(new BaseCardinalityKey("key1", "val1", "string"), Sets.newHashSet("1", "2"));
         shards.put(new BaseCardinalityKey("key2", "val2", "string"), Sets.newHashSet("2", "3"));
         shards.put(new BaseCardinalityKey("key3", "val3", "string"), Sets.newHashSet("2", "5"));
@@ -56,7 +71,7 @@ public class CalculateShardsVisitorTest {
 
     @Test
     public void shardRollUpAlternatingAndOrNodes() {
-        Map<CardinalityKey,Set<String>> shards = new HashMap<CardinalityKey, Set<String>>();
+        Map<TupleIndexKey,Set<String>> shards = new HashMap<TupleIndexKey, Set<String>>();
         shards.put(new BaseCardinalityKey("key1", "val1", "string"), Sets.newHashSet("1", "2"));
         shards.put(new BaseCardinalityKey("key2", "val2", "string"), Sets.newHashSet("2", "3"));
         shards.put(new BaseCardinalityKey("key3", "val3", "string"), Sets.newHashSet("2", "5"));

--- a/commons/src/test/java/org/calrissian/accumulorecipes/commons/support/criteria/visitors/CardinalityReorderVisitorTest.java
+++ b/commons/src/test/java/org/calrissian/accumulorecipes/commons/support/criteria/visitors/CardinalityReorderVisitorTest.java
@@ -24,7 +24,7 @@ import java.util.Map;
 
 import org.calrissian.accumulorecipes.commons.iterators.support.NodeToJexl;
 import org.calrissian.accumulorecipes.commons.support.criteria.BaseCardinalityKey;
-import org.calrissian.accumulorecipes.commons.support.criteria.CardinalityKey;
+import org.calrissian.accumulorecipes.commons.support.criteria.TupleIndexKey;
 import org.calrissian.mango.criteria.builder.QueryBuilder;
 import org.calrissian.mango.criteria.domain.AbstractKeyValueLeaf;
 import org.calrissian.mango.criteria.domain.AndNode;
@@ -38,7 +38,7 @@ public class CardinalityReorderVisitorTest {
     @Test
     public void test_basicReorder() {
 
-        Map<CardinalityKey, Long> cardinalities = new HashMap<CardinalityKey, Long>();
+        Map<TupleIndexKey, Long> cardinalities = new HashMap<TupleIndexKey, Long>();
         cardinalities.put(new BaseCardinalityKey("key1", "val1", "string"), 500l);
         cardinalities.put(new BaseCardinalityKey("key2", "val2", "string"), 50l);
         cardinalities.put(new BaseCardinalityKey("key3", "val3", "string"), 1000l);
@@ -60,7 +60,7 @@ public class CardinalityReorderVisitorTest {
     @Test
     public void test_pruneCardinalities_AndNode() {
 
-        Map<CardinalityKey, Long> cardinalities = new HashMap<CardinalityKey, Long>();
+        Map<TupleIndexKey, Long> cardinalities = new HashMap<TupleIndexKey, Long>();
         cardinalities.put(new BaseCardinalityKey("key1", "val1", "string"), 500l);
         cardinalities.put(new BaseCardinalityKey("key2", "val2", "string"), 0l);
         cardinalities.put(new BaseCardinalityKey("key3", "val3", "string"), 1000l);
@@ -81,7 +81,7 @@ public class CardinalityReorderVisitorTest {
     @Test
     public void test_pruneCardinalities_OrNode() {
 
-        Map<CardinalityKey, Long> cardinalities = new HashMap<CardinalityKey, Long>();
+        Map<TupleIndexKey, Long> cardinalities = new HashMap<TupleIndexKey, Long>();
         cardinalities.put(new BaseCardinalityKey("key1", "val1", "string"), 0l);
         cardinalities.put(new BaseCardinalityKey("key2", "val2", "string"), 0l);
         cardinalities.put(new BaseCardinalityKey("key3", "val3", "string"), 1000l);
@@ -102,7 +102,7 @@ public class CardinalityReorderVisitorTest {
     @Test
     public void test_pruneCardinalities_AllNodesZero() {
 
-        Map<CardinalityKey, Long> cardinalities = new HashMap<CardinalityKey, Long>();
+        Map<TupleIndexKey, Long> cardinalities = new HashMap<TupleIndexKey, Long>();
         cardinalities.put(new BaseCardinalityKey("key1", "val1", "string"), 0l);
         cardinalities.put(new BaseCardinalityKey("key2", "val2", "string"), 0l);
         cardinalities.put(new BaseCardinalityKey("key3", "val3", "string"), 0l);

--- a/commons/src/test/java/org/calrissian/accumulorecipes/commons/support/criteria/visitors/QueryOptimizerTest.java
+++ b/commons/src/test/java/org/calrissian/accumulorecipes/commons/support/criteria/visitors/QueryOptimizerTest.java
@@ -19,7 +19,7 @@ import static org.calrissian.mango.types.LexiTypeEncoders.LEXI_TYPES;
 import java.util.Collections;
 
 import org.calrissian.accumulorecipes.commons.iterators.support.NodeToJexl;
-import org.calrissian.accumulorecipes.commons.support.criteria.QueryOptimizer;
+import org.calrissian.accumulorecipes.commons.support.criteria.LogicalPlan;
 import org.calrissian.mango.criteria.builder.QueryBuilder;
 import org.calrissian.mango.criteria.domain.Node;
 import org.junit.Test;
@@ -31,7 +31,7 @@ public class QueryOptimizerTest {
 
         Node query = new QueryBuilder().and().and().or().end().end().end().build();
 
-        QueryOptimizer optimizer = new QueryOptimizer(query, LEXI_TYPES);
+        LogicalPlan optimizer = new LogicalPlan(query, LEXI_TYPES);
 
         System.out.println(new NodeToJexl(LEXI_TYPES).transform(Collections.singleton(""), optimizer.getOptimizedQuery()));
 

--- a/store/entity-store/src/main/java/org/calrissian/accumulorecipes/entitystore/support/EntityCardinalityKey.java
+++ b/store/entity-store/src/main/java/org/calrissian/accumulorecipes/entitystore/support/EntityCardinalityKey.java
@@ -15,11 +15,11 @@
  */
 package org.calrissian.accumulorecipes.entitystore.support;
 
-import org.apache.accumulo.core.data.Key;
-import org.calrissian.accumulorecipes.commons.support.criteria.BaseCardinalityKey;
-
 import static org.calrissian.accumulorecipes.commons.support.Constants.INDEX_K;
 import static org.calrissian.accumulorecipes.commons.support.Constants.INDEX_V;
+
+import org.apache.accumulo.core.data.Key;
+import org.calrissian.accumulorecipes.commons.support.criteria.BaseCardinalityKey;
 
 public class EntityCardinalityKey extends BaseCardinalityKey {
 
@@ -30,9 +30,11 @@ public class EntityCardinalityKey extends BaseCardinalityKey {
             this.alias = row.substring(row.indexOf("_" + INDEX_V + "_") + 3, row.indexOf("__"));
             this.normalizedValue = row.substring(row.indexOf("__") + 2, row.length());
             this.key = key.getColumnFamily().toString();
+            this.shard = key.getColumnQualifier().toString();
         } else if (row.contains("_" + INDEX_K + "_")) {
             this.key = row.substring(row.indexOf("_" + INDEX_K + "_") + 3, row.length());
             this.alias = key.getColumnFamily().toString();
+            this.shard = key.getColumnQualifier().toString();
         }
     }
 }

--- a/store/entity-store/src/main/java/org/calrissian/accumulorecipes/entitystore/support/EntityGlobalIndexVisitor.java
+++ b/store/entity-store/src/main/java/org/calrissian/accumulorecipes/entitystore/support/EntityGlobalIndexVisitor.java
@@ -39,6 +39,7 @@ import org.calrissian.mango.criteria.domain.AbstractKeyValueLeaf;
 import org.calrissian.mango.criteria.domain.HasLeaf;
 import org.calrissian.mango.criteria.domain.HasNotLeaf;
 import org.calrissian.mango.criteria.domain.Leaf;
+import org.calrissian.mango.criteria.domain.NotEqualsLeaf;
 import org.calrissian.mango.criteria.domain.ParentNode;
 import org.calrissian.mango.types.TypeRegistry;
 
@@ -90,7 +91,7 @@ public class EntityGlobalIndexVisitor implements GlobalIndexVisitor {
             String alias = registry.getAlias(kvLeaf.getValue());
 
             for (String type : types) {
-                if (isRangeLeaf(leaf) || leaf instanceof HasLeaf || leaf instanceof HasNotLeaf) {
+                if (isRangeLeaf(leaf) || leaf instanceof HasLeaf || leaf instanceof HasNotLeaf || leaf instanceof NotEqualsLeaf) {
                     if (alias != null)
                         ranges.add(prefix(type + "_" + INDEX_K + "_" + kvLeaf.getKey(), alias));
                     else

--- a/store/entity-store/src/main/java/org/calrissian/accumulorecipes/entitystore/support/EntityGlobalIndexVisitor.java
+++ b/store/entity-store/src/main/java/org/calrissian/accumulorecipes/entitystore/support/EntityGlobalIndexVisitor.java
@@ -32,7 +32,7 @@ import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
-import org.calrissian.accumulorecipes.commons.support.criteria.CardinalityKey;
+import org.calrissian.accumulorecipes.commons.support.criteria.TupleIndexKey;
 import org.calrissian.accumulorecipes.commons.support.criteria.visitors.GlobalIndexVisitor;
 import org.calrissian.accumulorecipes.commons.support.qfd.GlobalIndexValue;
 import org.calrissian.mango.criteria.domain.AbstractKeyValueLeaf;
@@ -50,8 +50,8 @@ public class EntityGlobalIndexVisitor implements GlobalIndexVisitor {
     private EntityShardBuilder shardBuilder;
 
     private Set<String> shards = new HashSet<String>();
-    private Map<CardinalityKey, Long> cardinalities = new HashMap<CardinalityKey, Long>();
-    private Map<CardinalityKey, Set<String>> mappedShards = new HashMap<CardinalityKey, Set<String>>();
+    private Map<TupleIndexKey, Long> cardinalities = new HashMap<TupleIndexKey, Long>();
+    private Map<TupleIndexKey, Set<String>> mappedShards = new HashMap<TupleIndexKey, Set<String>>();
 
     private Set<String> types;
 
@@ -64,12 +64,12 @@ public class EntityGlobalIndexVisitor implements GlobalIndexVisitor {
     }
 
     @Override
-    public Map<CardinalityKey, Long> getCardinalities() {
+    public Map<TupleIndexKey, Long> getCardinalities() {
         return cardinalities;
     }
 
     @Override
-    public Map<CardinalityKey, Set<String>> getShards() {
+    public Map<TupleIndexKey, Set<String>> getShards() {
         return mappedShards;
     }
 
@@ -106,7 +106,7 @@ public class EntityGlobalIndexVisitor implements GlobalIndexVisitor {
 
         for (Map.Entry<Key, Value> entry : indexScanner) {
 
-            CardinalityKey key = new EntityCardinalityKey(entry.getKey());
+            TupleIndexKey key = new EntityCardinalityKey(entry.getKey());
             Long cardinality = cardinalities.get(key);
             if (cardinality == null)
                 cardinality = 0l;

--- a/store/entity-store/src/test/java/org/calrissian/accumulorecipes/entitystore/impl/AccumuloEntityStoreTest.java
+++ b/store/entity-store/src/test/java/org/calrissian/accumulorecipes/entitystore/impl/AccumuloEntityStoreTest.java
@@ -685,7 +685,6 @@ public class AccumuloEntityStoreTest {
             x++;
             Entity e = itr.next();
             assertEquals("3.3.3.3", e.get("ip").getValue());
-
         }
         assertEquals(1, x);
     }

--- a/store/entity-store/src/test/java/org/calrissian/accumulorecipes/entitystore/support/EntityGlobalIndexVisitorTest.java
+++ b/store/entity-store/src/test/java/org/calrissian/accumulorecipes/entitystore/support/EntityGlobalIndexVisitorTest.java
@@ -18,7 +18,7 @@ package org.calrissian.accumulorecipes.entitystore.support;
 import org.apache.accumulo.core.client.*;
 import org.apache.accumulo.core.client.mock.MockInstance;
 import org.apache.accumulo.core.security.Authorizations;
-import org.calrissian.accumulorecipes.commons.support.criteria.CardinalityKey;
+import org.calrissian.accumulorecipes.commons.support.criteria.TupleIndexKey;
 import org.calrissian.accumulorecipes.commons.support.criteria.visitors.GlobalIndexVisitor;
 import org.calrissian.accumulorecipes.entitystore.EntityStore;
 import org.calrissian.accumulorecipes.entitystore.impl.AccumuloEntityStore;
@@ -72,7 +72,7 @@ public class EntityGlobalIndexVisitorTest {
 
 
         assertEquals(3, visitor.getCardinalities().size());
-        for (Map.Entry<CardinalityKey, Long> entry : visitor.getCardinalities().entrySet()) {
+        for (Map.Entry<TupleIndexKey, Long> entry : visitor.getCardinalities().entrySet()) {
             if (entry.getKey().getKey().equals("key1"))
                 assertEquals(2l, (long) entry.getValue());
             else if (entry.getKey().getKey().equals("key2"))

--- a/store/event-store/src/main/java/org/calrissian/accumulorecipes/eventstore/support/EventGlobalIndexVisitor.java
+++ b/store/event-store/src/main/java/org/calrissian/accumulorecipes/eventstore/support/EventGlobalIndexVisitor.java
@@ -22,7 +22,6 @@ import static org.calrissian.accumulorecipes.commons.support.Constants.NULL_BYTE
 import static org.calrissian.accumulorecipes.eventstore.support.EventKeyValueIndex.INDEX_SEP;
 import static org.calrissian.mango.criteria.support.NodeUtils.isRangeLeaf;
 import static org.calrissian.mango.types.LexiTypeEncoders.LEXI_TYPES;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -42,6 +41,7 @@ import org.calrissian.mango.criteria.domain.AbstractKeyValueLeaf;
 import org.calrissian.mango.criteria.domain.HasLeaf;
 import org.calrissian.mango.criteria.domain.HasNotLeaf;
 import org.calrissian.mango.criteria.domain.Leaf;
+import org.calrissian.mango.criteria.domain.NotEqualsLeaf;
 import org.calrissian.mango.criteria.domain.ParentNode;
 import org.calrissian.mango.types.TypeEncoder;
 import org.calrissian.mango.types.TypeRegistry;
@@ -82,7 +82,7 @@ public class EventGlobalIndexVisitor implements GlobalIndexVisitor {
     @Override
     public void exec() {
 
-        Collection<Range> ranges = new ArrayList<Range>();
+        Set<Range> ranges = new HashSet<Range>();
         for (Leaf leaf : leaves) {
 
             AbstractKeyValueLeaf kvLeaf = (AbstractKeyValueLeaf) leaf;
@@ -91,7 +91,7 @@ public class EventGlobalIndexVisitor implements GlobalIndexVisitor {
             String startShard = shardBuilder.buildShard(start.getTime(), 0);
             String stopShard = shardBuilder.buildShard(end.getTime(), shardBuilder.numPartitions() - 1) + END_BYTE;
 
-            if (isRangeLeaf(leaf) || leaf instanceof HasLeaf || leaf instanceof HasNotLeaf) {
+            if (isRangeLeaf(leaf) || leaf instanceof HasLeaf || leaf instanceof HasNotLeaf || leaf instanceof NotEqualsLeaf) {
 
                 if(leaf instanceof HasLeaf) {
                     String hasLeafAlias = registry.getAlias(((HasLeaf)leaf).getClazz());

--- a/store/event-store/src/main/java/org/calrissian/accumulorecipes/eventstore/support/EventGlobalIndexVisitor.java
+++ b/store/event-store/src/main/java/org/calrissian/accumulorecipes/eventstore/support/EventGlobalIndexVisitor.java
@@ -55,8 +55,8 @@ public class EventGlobalIndexVisitor implements GlobalIndexVisitor {
     private BatchScanner indexScanner;
     private EventShardBuilder shardBuilder;
 
-    private Set<String> shards = new HashSet<String>();
     private Map<CardinalityKey, Long> cardinalities = new HashMap<CardinalityKey, Long>();
+    private Map<CardinalityKey, Set<String>> mappedShards = new HashMap<CardinalityKey, Set<String>>();
     private Set<String> types;
 
     private Set<Leaf> leaves = new HashSet<Leaf>();
@@ -75,8 +75,8 @@ public class EventGlobalIndexVisitor implements GlobalIndexVisitor {
     }
 
     @Override
-    public Set<String> getShards() {
-        return shards;
+    public Map<CardinalityKey, Set<String>> getShards() {
+        return mappedShards;
     }
 
     @Override
@@ -133,7 +133,14 @@ public class EventGlobalIndexVisitor implements GlobalIndexVisitor {
                 cardinality = 0l;
             GlobalIndexValue value = new GlobalIndexValue(entry.getValue());
             cardinalities.put(key, cardinality + value.getCardinatlity());
-            shards.add(key.getShard());
+
+            Set<String> shardsForKey = mappedShards.get(key);
+            if(shardsForKey == null) {
+                shardsForKey = new HashSet<String>();
+                mappedShards.put(key, shardsForKey);
+            }
+
+            shardsForKey.add(key.getShard());
         }
 
         indexScanner.close();

--- a/store/event-store/src/main/java/org/calrissian/accumulorecipes/eventstore/support/EventGlobalIndexVisitor.java
+++ b/store/event-store/src/main/java/org/calrissian/accumulorecipes/eventstore/support/EventGlobalIndexVisitor.java
@@ -34,7 +34,7 @@ import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
-import org.calrissian.accumulorecipes.commons.support.criteria.CardinalityKey;
+import org.calrissian.accumulorecipes.commons.support.criteria.TupleIndexKey;
 import org.calrissian.accumulorecipes.commons.support.criteria.visitors.GlobalIndexVisitor;
 import org.calrissian.accumulorecipes.commons.support.qfd.GlobalIndexValue;
 import org.calrissian.accumulorecipes.eventstore.support.shard.EventShardBuilder;
@@ -55,8 +55,8 @@ public class EventGlobalIndexVisitor implements GlobalIndexVisitor {
     private BatchScanner indexScanner;
     private EventShardBuilder shardBuilder;
 
-    private Map<CardinalityKey, Long> cardinalities = new HashMap<CardinalityKey, Long>();
-    private Map<CardinalityKey, Set<String>> mappedShards = new HashMap<CardinalityKey, Set<String>>();
+    private Map<TupleIndexKey, Long> cardinalities = new HashMap<TupleIndexKey, Long>();
+    private Map<TupleIndexKey, Set<String>> mappedShards = new HashMap<TupleIndexKey, Set<String>>();
     private Set<String> types;
 
     private Set<Leaf> leaves = new HashSet<Leaf>();
@@ -70,12 +70,12 @@ public class EventGlobalIndexVisitor implements GlobalIndexVisitor {
     }
 
     @Override
-    public Map<CardinalityKey, Long> getCardinalities() {
+    public Map<TupleIndexKey, Long> getCardinalities() {
         return cardinalities;
     }
 
     @Override
-    public Map<CardinalityKey, Set<String>> getShards() {
+    public Map<TupleIndexKey, Set<String>> getShards() {
         return mappedShards;
     }
 
@@ -127,7 +127,7 @@ public class EventGlobalIndexVisitor implements GlobalIndexVisitor {
 
         for (Map.Entry<Key, Value> entry : indexScanner) {
 
-            CardinalityKey key = new EventCardinalityKey(entry.getKey());
+            TupleIndexKey key = new EventCardinalityKey(entry.getKey());
             Long cardinality = cardinalities.get(key);
             if (cardinality == null)
                 cardinality = 0l;
@@ -142,6 +142,8 @@ public class EventGlobalIndexVisitor implements GlobalIndexVisitor {
 
             shardsForKey.add(key.getShard());
         }
+
+        System.out.println(mappedShards);
 
         indexScanner.close();
     }

--- a/store/event-store/src/test/java/org/calrissian/accumulorecipes/eventstore/impl/AccumuloEventStoreTest.java
+++ b/store/event-store/src/test/java/org/calrissian/accumulorecipes/eventstore/impl/AccumuloEventStoreTest.java
@@ -553,6 +553,7 @@ public class AccumuloEventStoreTest {
         store.flush();
 
         AccumuloTestUtils.dumpTable(connector, "eventStore_shard");
+        AccumuloTestUtils.dumpTable(connector, "eventStore_index");
 
         Node query = new QueryBuilder()
                 .and()

--- a/store/event-store/src/test/java/org/calrissian/accumulorecipes/eventstore/support/EventGlobalIndexVisitorTest.java
+++ b/store/event-store/src/test/java/org/calrissian/accumulorecipes/eventstore/support/EventGlobalIndexVisitorTest.java
@@ -33,7 +33,7 @@ import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.mock.MockInstance;
 import org.apache.accumulo.core.security.Authorizations;
 import org.calrissian.accumulorecipes.commons.support.Constants;
-import org.calrissian.accumulorecipes.commons.support.criteria.CardinalityKey;
+import org.calrissian.accumulorecipes.commons.support.criteria.TupleIndexKey;
 import org.calrissian.accumulorecipes.commons.support.criteria.visitors.GlobalIndexVisitor;
 import org.calrissian.accumulorecipes.eventstore.EventStore;
 import org.calrissian.accumulorecipes.eventstore.impl.AccumuloEventStore;
@@ -78,7 +78,7 @@ public class EventGlobalIndexVisitorTest {
 
 
         assertEquals(3, visitor.getCardinalities().size());
-        for (Map.Entry<CardinalityKey, Long> entry : visitor.getCardinalities().entrySet()) {
+        for (Map.Entry<TupleIndexKey, Long> entry : visitor.getCardinalities().entrySet()) {
             if (entry.getKey().getKey().equals("key1"))
                 assertEquals(2l, (long) entry.getValue());
             else if (entry.getKey().getKey().equals("key2"))

--- a/thirdparty/spark/src/main/scala/org/calrissian/accumulorecipes/spark/sql/EventStoreFiltered.scala
+++ b/thirdparty/spark/src/main/scala/org/calrissian/accumulorecipes/spark/sql/EventStoreFiltered.scala
@@ -73,7 +73,6 @@ class EventStoreFilteredScan(inst: String, zk: String, user: String, pass: Strin
   override def uniqueKeys(connector: Connector): CloseableIterable[Pair[String, String]] =
     EventKeyValueIndex.uniqueKeys(connector, AccumuloEventStore.DEFAULT_IDX_TABLE_NAME, "", eventType, 10, new Auths)
 
-
   override def buildRDD(columns: Array[String], filters: Array[Filter], query: Node): RDD[T] = {
     val conf = sqlContext.sparkContext.hadoopConfiguration
     val job = Job.getInstance(conf)

--- a/thirdparty/spark/src/test/scala/org/calrissian/accumulorecipes/spark/sql/EntityStoreFilteredTest.scala
+++ b/thirdparty/spark/src/test/scala/org/calrissian/accumulorecipes/spark/sql/EntityStoreFilteredTest.scala
@@ -68,7 +68,7 @@ object EntityStoreFilteredTest {
 
   private def persistEntities = {
     val entity = new BaseEntity("type", "id")
-    entity.put(new Tuple("key1", "val1"))
+    entity.put(new Tuple("key1", true))
     entity.put(new Tuple("key2", 5))
 
     entityStore.save(Collections.singleton(entity))
@@ -113,7 +113,7 @@ class EntityStoreFilteredTest {
   @Test
   def testSelectAndWhereSingleOperator() {
 
-    val rows = sqlContext.sql("SELECT key1,key2 FROM entities WHERE (key1 = 'val1')").collect
+    val rows = sqlContext.sql("SELECT key1,key2 FROM entities WHERE (key1 = true)").collect
 
     Assert.assertEquals(1, rows.length)
     Assert.assertEquals(5, rows(0).getAs[Int](1))
@@ -169,7 +169,7 @@ class EntityStoreFilteredTest {
     Assert.assertEquals("val1", rows(0).getAs(0))
   }
 
-  @Test(expected = classOf[TreeNodeException[_]])
+  @Test(expected = classOf[TIreeNodeException[_]])
   def testSelectFieldNotInSchema: Unit = sqlContext.sql("SELECT doesntExist FROM entities").collect
 
   @Test

--- a/thirdparty/spark/src/test/scala/org/calrissian/accumulorecipes/spark/sql/EntityStoreFilteredTest.scala
+++ b/thirdparty/spark/src/test/scala/org/calrissian/accumulorecipes/spark/sql/EntityStoreFilteredTest.scala
@@ -68,7 +68,7 @@ object EntityStoreFilteredTest {
 
   private def persistEntities = {
     val entity = new BaseEntity("type", "id")
-    entity.put(new Tuple("key1", true))
+    entity.put(new Tuple("key1", "val1"))
     entity.put(new Tuple("key2", 5))
 
     entityStore.save(Collections.singleton(entity))
@@ -113,7 +113,7 @@ class EntityStoreFilteredTest {
   @Test
   def testSelectAndWhereSingleOperator() {
 
-    val rows = sqlContext.sql("SELECT key1,key2 FROM entities WHERE (key1 = true)").collect
+    val rows = sqlContext.sql("SELECT key1,key2 FROM entities WHERE (key1 = 'val1')").collect
 
     Assert.assertEquals(1, rows.length)
     Assert.assertEquals(5, rows(0).getAs[Int](1))
@@ -169,7 +169,7 @@ class EntityStoreFilteredTest {
     Assert.assertEquals("val1", rows(0).getAs(0))
   }
 
-  @Test(expected = classOf[TIreeNodeException[_]])
+  @Test(expected = classOf[TreeNodeException[_]])
   def testSelectFieldNotInSchema: Unit = sqlContext.sql("SELECT doesntExist FROM entities").collect
 
   @Test

--- a/thirdparty/spark/src/test/scala/org/calrissian/accumulorecipes/spark/sql/EventStoreCatalystTest.scala
+++ b/thirdparty/spark/src/test/scala/org/calrissian/accumulorecipes/spark/sql/EventStoreCatalystTest.scala
@@ -67,7 +67,7 @@ object EventStoreCatalystTest {
 
   private def persistEvents = {
     val event = new BaseEvent("type", "id")
-    event.put(new Tuple("key1", true))
+    event.put(new Tuple("key1", "val1"))
     event.put(new Tuple("key2", 5))
 
 
@@ -166,7 +166,7 @@ class EventStoreCatalystTest {
   @Test
   def testSelectAndWhereSingleOperator() {
 
-    val rows = sqlContext.sql("SELECT key1, key2 FROM events WHERE (key1 = true)").collect
+    val rows = sqlContext.sql("SELECT key1, key2 FROM events WHERE (key1 = 'val1')").collect
 
     Assert.assertEquals(1, rows.length)
     Assert.assertEquals(5, rows(0).getAs[Int](1))

--- a/thirdparty/spark/src/test/scala/org/calrissian/accumulorecipes/spark/sql/EventStoreCatalystTest.scala
+++ b/thirdparty/spark/src/test/scala/org/calrissian/accumulorecipes/spark/sql/EventStoreCatalystTest.scala
@@ -18,6 +18,7 @@ package org.calrissian.accumulorecipes.spark.sql
 import java.util.Collections
 
 import org.apache.accumulo.minicluster.impl.MiniAccumuloClusterImpl
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.catalyst.errors.TreeNodeException
 import org.apache.spark.{SparkConf, SparkContext}
@@ -66,7 +67,7 @@ object EventStoreCatalystTest {
 
   private def persistEvents = {
     val event = new BaseEvent("type", "id")
-    event.put(new Tuple("key1", "val1"))
+    event.put(new Tuple("key1", true))
     event.put(new Tuple("key2", 5))
 
 
@@ -97,6 +98,8 @@ class EventStoreCatalystTest {
     createTempTable
   }
 
+
+
   @After
   def teardownTest: Unit = {
     sqlContext.dropTempTable("events")
@@ -117,7 +120,7 @@ class EventStoreCatalystTest {
 
     AccumuloTestUtils.dumpTable(miniCluster.getConnector("root", "secret"), "eventStore_shard")
 
-    val rows = sqlContext.sql("SELECT e.key1,e.key2,t.key3 FROM events e INNER JOIN events2 t ON e.key1 = t.key1").collect
+    val rows = sqlContext.sql("SELECT e.key1,e.key2,t.key3 FROM events e  JOIN events2 t ON e.key1 = t.key1").collect
 
     System.out.println(rows.toList)
     Assert.assertEquals(1, rows.length)
@@ -126,6 +129,18 @@ class EventStoreCatalystTest {
     Assert.assertEquals("val3", rows(0).getAs[String](2))
 
     sqlContext.dropTempTable("events2")
+  }
+
+  val myfunc = () => {
+    1
+  }
+
+  @Test
+  def test() = {
+
+    val rdd:RDD[Int] = sqlContext.sparkContext.parallelize(0 to 500)
+    val rdd2: RDD[Seq[Int]] = rdd.mapPartitions(_.grouped(10))
+    System.out.println(rdd2.collect.toList)
   }
 
   @Test
@@ -151,7 +166,7 @@ class EventStoreCatalystTest {
   @Test
   def testSelectAndWhereSingleOperator() {
 
-    val rows = sqlContext.sql("SELECT key1, key2 FROM events WHERE (key1 = 'val1')").collect
+    val rows = sqlContext.sql("SELECT key1, key2 FROM events WHERE (key1 = true)").collect
 
     Assert.assertEquals(1, rows.length)
     Assert.assertEquals(5, rows(0).getAs[Int](1))

--- a/thirdparty/spark/src/test/scala/org/calrissian/accumulorecipes/spark/sql/EventStoreFilteredTest.scala
+++ b/thirdparty/spark/src/test/scala/org/calrissian/accumulorecipes/spark/sql/EventStoreFilteredTest.scala
@@ -66,7 +66,7 @@ object EventStoreFilteredTest {
 
   private def persistEvents = {
     val event = new BaseEvent("type", "id")
-    event.put(new Tuple("key1", "val1"))
+    event.put(new Tuple("key1", true))
     event.put(new Tuple("key2", 5))
 
 
@@ -141,7 +141,7 @@ class EventStoreFilteredTest {
   @Test
   def testSelectAndWhereSingleOperator() {
 
-    val rows = sqlContext.sql("SELECT key1, key2 FROM events WHERE (key1 = 'val1')").collect
+    val rows = sqlContext.sql("SELECT key1, key2 FROM events WHERE (key1 = true and key2 = 5)").collect
 
     Assert.assertEquals(1, rows.length)
     Assert.assertEquals(5, rows(0).getAs[Int](1))

--- a/thirdparty/spark/src/test/scala/org/calrissian/accumulorecipes/spark/sql/EventStoreFilteredTest.scala
+++ b/thirdparty/spark/src/test/scala/org/calrissian/accumulorecipes/spark/sql/EventStoreFilteredTest.scala
@@ -66,7 +66,7 @@ object EventStoreFilteredTest {
 
   private def persistEvents = {
     val event = new BaseEvent("type", "id")
-    event.put(new Tuple("key1", true))
+    event.put(new Tuple("key1", "val1"))
     event.put(new Tuple("key2", 5))
 
 
@@ -141,7 +141,7 @@ class EventStoreFilteredTest {
   @Test
   def testSelectAndWhereSingleOperator() {
 
-    val rows = sqlContext.sql("SELECT key1, key2 FROM events WHERE (key1 = true and key2 = 5)").collect
+    val rows = sqlContext.sql("SELECT key1, key2 FROM events WHERE (key1 = 'val1' and key2 = 5)").collect
 
     Assert.assertEquals(1, rows.length)
     Assert.assertEquals(5, rows(0).getAs[Int](1))


### PR DESCRIPTION
Posting up for initial review. There are still many edge cases (and a failing test on the entity store) as well as much much more unit tests to be written. 

Also renamed QueryOptimizer to LogicalPlan since that name now more fits its purpose.